### PR TITLE
Add lambda conditional switch (LambdaConditionalSwitch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,41 @@ class MyWidget extends StatelessWidget {
 }
 ```
 
+### Lambda switch condition:
+
+Returns the first lambda which matches (returns true).
+
+Lambdas are evaluated in order therefore it would make sense to order them so the most likely matched conditions are placed first
+and the least likely last.
+
+
+```dart
+class MyWidget extends StatelessWidget {
+  var counter = 8;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        LambdaConditionalSwitch.single(
+          context: context,
+          caseBuilders: {
+                () => counter == 0: (BuildContext context) =>
+            const Text('Counter is 0!'),
+                () => counter > 0 && counter % 5 == 0: (BuildContext context) =>
+            const Text('Counter is divisible by 5!'),
+                () => counter == 8: (BuildContext context) =>
+            const Text('Counter is 8!'),
+          },
+          fallbackBuilder: (BuildContext context) =>
+          const Text('None of the cases matched!'),
+        ),
+      ],
+    );
+  }
+}
+```
+
 ## Want a list of widgets?
 
 If you want to conditionally render a list of widgets (`List<Widget>`) instead of a single one. Use `Conditional.list()` and `ConditionalSwitch.list()`!

--- a/lib/lambda_conditional_switch.dart
+++ b/lib/lambda_conditional_switch.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+/// Lambda conditional rendering switch class
+class LambdaConditionalSwitch {
+  LambdaConditionalSwitch._();
+
+  /// A function which returns a single `Widget`
+  ///
+  /// - [caseBuilders] is a `Map` of lambda to `Widget` builders,
+  /// when one of the lambdas returns true,
+  /// the corresponding `Widget` builder will be used.
+  /// - [fallbackBuilder] is a function which returns a `Widget`,
+  ///  it is used when none of the lambdas in [caseBuilders] matches
+  /// the value returns by [valueBuilder].
+  static Widget single({
+    required BuildContext context,
+    required Map<bool Function(), Widget Function(BuildContext context)>
+        caseBuilders,
+    required Widget Function(BuildContext context) fallbackBuilder,
+  }) {
+    for (var lambda in caseBuilders.keys) {
+      if (lambda.call()) {
+        return caseBuilders[lambda]!(context);
+      }
+    }
+    return fallbackBuilder(context);
+  }
+
+  /// A function which returns a `List<Widget>`
+  ///
+  /// - [caseBuilders] is a `Map` of lambda to `List<Widget>` builders,
+  /// when one of the lambdas returns true,
+  /// the corresponding `List<Widget>` builder will be used.
+  /// - [fallbackBuilder] is a function which returns a `List<Widget>`,
+  ///  it is used when none of the lambdas in [caseBuilders] matches
+  /// the value returns by [valueBuilder].
+  static List<Widget> list({
+    required BuildContext context,
+    required Map<bool Function(), List<Widget> Function(BuildContext context)>
+        caseBuilders,
+    required List<Widget> Function(BuildContext context) fallbackBuilder,
+  }) {
+    for (var lambda in caseBuilders.keys) {
+      if (lambda.call()) {
+        return caseBuilders[lambda]!(context);
+      }
+    }
+    return fallbackBuilder(context);
+  }
+}

--- a/test/lambda_conditional_switch_test.dart
+++ b/test/lambda_conditional_switch_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_conditional_rendering/lambda_conditional_switch.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets(
+    'Render widget by case "A" builder if value is "A"',
+    (WidgetTester tester) async {
+      const value = 'A';
+
+      final Widget aConditionWidget = Container();
+      final Widget fallbackWidget = Container();
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return LambdaConditionalSwitch.single(
+              context: context,
+              caseBuilders: {() => value == 'A': (_) => aConditionWidget},
+              fallbackBuilder: (_) => fallbackWidget,
+            );
+          },
+        ),
+      );
+
+      expect(find.byWidget(aConditionWidget), findsOneWidget);
+      expect(find.byWidget(fallbackWidget), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Render widget by case "B" builder if value is "B"',
+    (WidgetTester tester) async {
+      const value = 'B';
+
+      final Widget aConditionWidget = Container();
+      final Widget bConditionWidget = Container();
+      final Widget fallbackWidget = Container();
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return LambdaConditionalSwitch.single(
+              context: context,
+              caseBuilders: {
+                () => value == 'A': (_) => aConditionWidget,
+                () => value == 'B': (_) => bConditionWidget,
+              },
+              fallbackBuilder: (_) => fallbackWidget,
+            );
+          },
+        ),
+      );
+
+      expect(find.byWidget(aConditionWidget), findsNothing);
+      expect(find.byWidget(bConditionWidget), findsOneWidget);
+      expect(find.byWidget(fallbackWidget), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Render widget by `fallbackBuilder` if value is not "A"',
+    (WidgetTester tester) async {
+      const value = 'Z';
+
+      final Widget aConditionWidget = Container();
+      final Widget fallbackWidget = Container();
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return LambdaConditionalSwitch.single(
+              context: context,
+              caseBuilders: {() => value == 'A': (_) => aConditionWidget},
+              fallbackBuilder: (_) => fallbackWidget,
+            );
+          },
+        ),
+      );
+
+      expect(find.byWidget(fallbackWidget), findsOneWidget);
+      expect(find.byWidget(aConditionWidget), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Render list of widgets by case "A" builder if value is "A"',
+    (WidgetTester tester) async {
+      const value = 'A';
+
+      final List<Widget> aConditionWidgetList = [Container()];
+      final List<Widget> fallbackWidgetList = [Container()];
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return Column(
+              children: LambdaConditionalSwitch.list(
+                context: context,
+                caseBuilders: {() => value == 'A': (_) => aConditionWidgetList},
+                fallbackBuilder: (_) => fallbackWidgetList,
+              ),
+            );
+          },
+        ),
+      );
+
+      for (Widget widget in aConditionWidgetList) {
+        expect(find.byWidget(widget), findsOneWidget);
+      }
+
+      for (Widget widget in fallbackWidgetList) {
+        expect(find.byWidget(widget), findsNothing);
+      }
+    },
+  );
+
+  testWidgets(
+    'Render list of widgets by `fallbackBuilder` if value is not `A`',
+    (WidgetTester tester) async {
+      const value = 'Z';
+
+      final List<Widget> aConditionWidgetList = [Container()];
+      final List<Widget> fallbackWidgetList = [Container()];
+      await tester.pumpWidget(
+        Builder(
+          builder: (BuildContext context) {
+            return Column(
+              children: LambdaConditionalSwitch.list(
+                context: context,
+                caseBuilders: {() => value == 'A': (_) => aConditionWidgetList},
+                fallbackBuilder: (_) => fallbackWidgetList,
+              ),
+            );
+          },
+        ),
+      );
+
+      for (Widget widget in fallbackWidgetList) {
+        expect(find.byWidget(widget), findsOneWidget);
+      }
+
+      for (Widget widget in aConditionWidgetList) {
+        expect(find.byWidget(widget), findsNothing);
+      }
+    },
+  );
+}


### PR DESCRIPTION
Hi,

I've added a lambda conditional switch because it would be super useful for my use case.

It allows you to pass in a list of lambdas and the widget from the first lambda which returns true is returned.

I guess I could have used the exiting ConditionalSwitch to do what I need by manipulating the variable passed to valueBuilder but this felt cleaner.

Thanks